### PR TITLE
fix: no cookie error

### DIFF
--- a/lib/historical.ex
+++ b/lib/historical.ex
@@ -45,13 +45,14 @@ defmodule YahooFinance.Historical do
   end
 
   defp extract_cookie(response_headers) do
-    [{_, cookie}] =
-      Enum.filter(response_headers, fn
-        {"Set-Cookie", _} -> true
-        _ -> false
-      end)
-
-    cookie
+    Enum.filter(response_headers, fn
+      {"Set-Cookie", _} -> true
+      _ -> false
+    end)
+    |> (fn
+      [{_, cookie}] -> cookie
+      _ -> nil
+    end).()
   end
 
   # The crumb is the token tied to the cookie for the download request.


### PR DESCRIPTION
I got error when running:

```elixir
YahooFinance.historical("AAPL", "2018-05-01", "2018-05-04")
# ** (MatchError) no match of right hand side value: []
#     (yahoo_finance_elixir 0.1.3) lib/historical.ex:49: YahooFinance.Historical.extract_cookie/1
#     (yahoo_finance_elixir 0.1.3) lib/historical.ex:37: YahooFinance.Historical.handle_success/4
#     /data/money.livemd#cell:32a7pxf6ffn2hjjya7knptb25f56sa3p:1: (file)
```

seems like Yahoo finance doesn't return cookie (`Set-Cookie` header) anymore